### PR TITLE
docs: add asset and animation suggestions

### DIFF
--- a/markdown/asset-organization.md
+++ b/markdown/asset-organization.md
@@ -1,0 +1,29 @@
+# Asset Organization Review
+
+This document summarizes recommendations for cleaning and organizing assets in the project.
+
+## Boot Background
+- `boot-asset-pack.json` references `assets/images/bg.png`, which doesn't exist.
+- Replace the reference with an existing background, such as `assets/images/screens/startscreen.png`.
+
+## Missing TrapHouse Assets
+- `preload-asset-pack.json` expects `assets/images/levels/traphouse/traphousebig.png` but the file is missing.
+- Either provide this PNG or remove the entry and related scene until assets exist.
+
+## Unused Tilemap JSON
+- `Preloader.ts` loads `assets/tilemaps/player-home-interior.json`, which isn't present.
+- Remove the load call or supply the JSON if still needed.
+
+## Source Files in Public Bundle
+- `.aseprite` sources and palette PNGs reside in `public/assets/images`.
+- Move development-only files to a separate directory (e.g., `public/assets/aseprite`) so they aren't served to players.
+
+## Duplicate and Temporary Files
+- Remove unused files such as `loop-player.png`, `main-player.png`, and `apartment2-interior copy.json`.
+- Clean out placeholders like `public/publicroot` and drafts like `player-draft*.aseprite`.
+
+## Collision Data Placement
+- Collision JSON files are stored with level images.
+- Consider moving them to `public/assets/collision/` or `public/assets/tilemaps/` and update load paths accordingly.
+
+These changes keep the public bundle lean and ensure scenes load only the assets they need.

--- a/markdown/sprite-animation-workflow.md
+++ b/markdown/sprite-animation-workflow.md
@@ -1,0 +1,32 @@
+# Sprite Animation Workflow
+
+This guide outlines how to export and integrate animated sprites and map backgrounds.
+
+## Exporting Animated Sprites in Aseprite
+1. **Tag frames** for each action or direction (e.g., `idle-down`, `walk-left`).
+2. **File → Export Sprite Sheet…**
+   - Choose "By Tag" or "All Frames".
+   - Set frame dimensions (e.g., 32×32).
+   - Export to `public/assets/images/sprites/<name>.png` and save JSON metadata if needed.
+3. **Add to Asset Pack**
+   - Register the sheet in `public/assets/preload-asset-pack.json` with type `spritesheet` and the correct `frameWidth` and `frameHeight`.
+4. **Define Animations in Phaser**
+   ```ts
+   this.anims.create({
+     key: 'walk-down',
+     frames: this.anims.generateFrameNumbers('player', { start: 0, end: n }),
+     frameRate: 8,
+     repeat: -1,
+   });
+   ```
+5. **Use in Scenes**
+   - `this.physics.add.sprite(x, y, 'player').play('walk-down');`
+
+## Exporting Map Backgrounds
+1. **Static PNG**
+   - Export the full map image to `public/assets/images/levels/<map>.png`.
+2. **Collision Data (Optional)**
+   - Run the `scripts/export-collision.lua` script to produce a JSON file of slice collisions.
+   - Place the JSON in `public/assets/tilemaps/` and load it with `this.load.json()` during preload.
+
+Animated tiles like water should be exported as separate sprite sheets and layered over the static map in Phaser.


### PR DESCRIPTION
## Summary
- Add asset organization review outlining cleanup recommendations
- Document sprite animation and map export workflow in dedicated guide

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_689a7e113398832b86ab0b911fd6211e