### PR TITLE
refactor: centralize collision and trigger setup in map scenes

### DIFF
--- a/src/game/scenes/BaseMapScene.ts
+++ b/src/game/scenes/BaseMapScene.ts
@@ -1,0 +1,84 @@
+import Phaser from 'phaser';
+import { CollisionLoader } from '../utils/CollisionLoader';
+import { TriggerManager } from '../utils/TriggerManager';
+
+export interface TriggerConfig {
+    tileX: number;
+    tileY: number;
+    targetScene: string;
+    key?: string;
+}
+
+export interface MapSceneConfig {
+    collision?: {
+        key: string;
+        path: string;
+        debug?: boolean;
+    };
+    triggers?: {
+        entries: TriggerConfig[];
+        debug?: boolean;
+    };
+}
+
+export default class BaseMapScene extends Phaser.Scene {
+    protected player!: Phaser.Physics.Arcade.Sprite;
+
+    private collisionLoader?: CollisionLoader;
+    private triggerManager?: TriggerManager;
+    private collisionGroup?: Phaser.Physics.Arcade.StaticGroup;
+    private collisionRects: Phaser.GameObjects.Rectangle[] = [];
+
+    preload(config?: MapSceneConfig): void {
+        if (config?.collision) {
+            this.collisionLoader = new CollisionLoader(this);
+            this.loadCollision(config.collision);
+        }
+    }
+
+    create(config?: MapSceneConfig): void {
+        if (config?.collision) {
+            this.loadCollision(config.collision);
+        }
+        if (config?.triggers) {
+            this.loadTriggers(config.triggers.entries, config.triggers.debug);
+        }
+    }
+
+    protected loadCollision(config: { key: string; path: string; debug?: boolean }): void {
+        if (!this.collisionLoader) {
+            this.collisionLoader = new CollisionLoader(this);
+        }
+
+        const data = this.cache.json.get(config.key);
+        if (!data) {
+            this.collisionLoader.loadSliceCollision(config.key, config.path);
+            this.load.on('loaderror', (file: any) => {
+                if (file.key === config.key) {
+                    console.warn(`Collision data not found for key ${config.key} - no collision will be active`);
+                }
+            });
+            return;
+        }
+
+        this.collisionGroup = this.physics.add.staticGroup();
+        this.collisionRects = this.collisionLoader.createSliceCollision(config.key, this.collisionGroup);
+        if (this.player) {
+            this.collisionLoader.setupPlayerCollision(this.player, this.collisionGroup);
+        }
+        if (config.debug) {
+            this.collisionLoader.enableDebugVisualization(this.collisionRects);
+        }
+    }
+
+    protected loadTriggers(entries: TriggerConfig[], debug?: boolean): void {
+        this.triggerManager = new TriggerManager(this);
+        entries.forEach(t => this.triggerManager!.addSceneTrigger(t.tileX, t.tileY, t.targetScene, t.key));
+        if (this.player) {
+            this.triggerManager.setupPlayerTriggers(this.player);
+        }
+        if (debug) {
+            this.triggerManager.enableDebugVisualization();
+        }
+    }
+}

--- a/src/game/scenes/apartment-interior.ts
+++ b/src/game/scenes/apartment-interior.ts
@@ -1,118 +1,68 @@
 import Phaser from 'phaser';
+import BaseMapScene, { MapSceneConfig } from './BaseMapScene';
 import { PlayerController } from '../player/PlayerController';
 import { IPlayerMovementInput } from '../player/types/PlayerTypes';
-import { CollisionLoader } from '../utils/CollisionLoader';
-import { TriggerManager } from '../utils/TriggerManager';
 
-export default class ApartmentInterior extends Phaser.Scene {
+export default class ApartmentInterior extends BaseMapScene {
+    private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
+    private playerController!: PlayerController;
 
-	constructor() {
-		super("apartment-interior");
-	}
+    private sceneConfig: MapSceneConfig = {
+        collision: {
+            key: 'apartmentCollision',
+            path: 'assets/images/levels/apartment-interior.json',
+        },
+        triggers: {
+            entries: [
+                { tileX: 11, tileY: 15, targetScene: 'pacc-house', key: 'door_left' },
+                { tileX: 12, tileY: 15, targetScene: 'pacc-house', key: 'door_right' },
+            ],
+        },
+    };
 
-	private player!: Phaser.Physics.Arcade.Sprite;
-	private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
-	private collisionGroup!: Phaser.Physics.Arcade.StaticGroup;
-	private playerController!: PlayerController;
-	private collisionLoader!: CollisionLoader;
-	private triggerManager!: TriggerManager;
-	private collisionRects: Phaser.GameObjects.Rectangle[] = [];
+    constructor() {
+        super('apartment-interior');
+    }
 
-	preload() {
-		// Initialize collision loader
-		this.collisionLoader = new CollisionLoader(this);
-		
-		// Load slice collision data from apartment-interior.json (without the "2")
-		this.collisionLoader.loadSliceCollision('apartmentCollision', 'assets/images/levels/apartment-interior.json');
-		
-		// Handle load errors gracefully
-		this.load.on('loaderror', (file: any) => {
-			if (file.key === 'apartmentCollision') {
-				console.warn('Collision data not found for ApartmentInterior - no collision will be active');
-			}
-		});
-	}
+    preload() {
+        super.preload(this.sceneConfig);
+    }
 
-	create() {
-		// Background image - using apartment-interior.png (without the "2")
-		this.add.image(192, 144, "apartment-interior");
+    create() {
+        this.add.image(192, 144, 'apartment-interior');
 
-		// Create the player physics sprite at center of screen
-		this.player = this.physics.add.sprite(192, 144, 'loop-player');
-		this.player.play('player-idle-down');
+        this.player = this.physics.add.sprite(192, 144, 'loop-player');
+        this.player.play('player-idle-down');
+        this.player.setSize(12, 12);
+        this.player.setOffset(11, 20);
+        this.player.setCollideWorldBounds(true);
 
-		// Set up player physics body - 12x12 centered horizontally, bottom aligned
-		this.player.setSize(12, 12); // Collision box size
-		this.player.setOffset(11, 20); // Offset 11 pixels from left to center, 20 from top for bottom 12 pixels
-		this.player.setCollideWorldBounds(true);
+        this.cursors = this.input.keyboard!.createCursorKeys();
 
-		// Set up input
-		this.cursors = this.input.keyboard!.createCursorKeys();
+        this.physics.world.setBounds(0, 0, 384, 288);
+        this.cameras.main.setBounds(0, 0, 384, 288);
+        this.cameras.main.startFollow(this.player);
+        this.cameras.main.setLerp(0.1, 0.1);
 
-		// Set world bounds for physics and camera
-		this.physics.world.setBounds(0, 0, 384, 288);
-		this.cameras.main.setBounds(0, 0, 384, 288);
-		this.cameras.main.startFollow(this.player);
-		this.cameras.main.setLerp(0.1, 0.1);
+        super.create(this.sceneConfig);
 
-		// Create slice-based collision system
-		this.collisionGroup = this.physics.add.staticGroup();
-		this.setupSliceCollision();
+        this.playerController = new PlayerController(this.player);
+    }
 
-		// Initialize trigger system
-		this.triggerManager = new TriggerManager(this);
-		this.setupTriggers();
+    update() {
+        const input: IPlayerMovementInput = {
+            up: this.cursors.up.isDown,
+            down: this.cursors.down.isDown,
+            left: this.cursors.left.isDown,
+            right: this.cursors.right.isDown,
+        };
 
-		// Initialize player controller
-		this.playerController = new PlayerController(this.player);
-	}
+        this.playerController.update(input);
 
-	private setupSliceCollision() {
-		// Create collision bodies from Aseprite slice data
-		this.collisionRects = this.collisionLoader.createSliceCollision('apartmentCollision', this.collisionGroup);
-		
-		// Setup player collision with the collision group
-		this.collisionLoader.setupPlayerCollision(this.player, this.collisionGroup);
-		
-		// Uncomment below to enable debug visualization (red rectangles)
-		// this.collisionLoader.enableDebugVisualization(this.collisionRects);
-		
-		console.log('✅ Slice-based collision system enabled for ApartmentInterior');
-	}
-
-	private setupTriggers() {
-		// Add scene transition triggers at tiles 11,15 and 12,15 -> pacc-house
-		// Grid: 24x18 tiles (0-23 horizontal, 0-17 vertical)
-		// Tile 15 = row 15 out of 18 = near bottom of room
-		this.triggerManager.addSceneTrigger(11, 15, 'pacc-house', 'door_left');
-		this.triggerManager.addSceneTrigger(12, 15, 'pacc-house', 'door_right');
-		
-		// Setup player trigger collision
-		this.triggerManager.setupPlayerTriggers(this.player);
-		
-		// Uncomment below to enable debug visualization (green rectangles)
-		// this.triggerManager.enableDebugVisualization();
-		
-		console.log('✅ Scene triggers setup: tiles (11,15) and (12,15) -> pacc-house');
-	}
-
-	update() {
-		// Create input object from cursors
-		const input: IPlayerMovementInput = {
-			up: this.cursors.up.isDown,
-			down: this.cursors.down.isDown,
-			left: this.cursors.left.isDown,
-			right: this.cursors.right.isDown
-		};
-
-		// Update player via controller
-		this.playerController.update(input);
-
-		// Debug log when moving (maintain existing debug behavior)
-		const playerState = this.playerController.getState();
-		if (playerState.currentState === 'walking') {
-			const sprite = this.playerController.getSprite();
-			console.log(`Moving: ${playerState.lastDirection}, Position: ${sprite.x}, ${sprite.y}`);
-		}
-	}
+        const playerState = this.playerController.getState();
+        if (playerState.currentState === 'walking') {
+            const sprite = this.playerController.getSprite();
+            console.log(`Moving: ${playerState.lastDirection}, Position: ${sprite.x}, ${sprite.y}`);
+        }
+    }
 }

--- a/src/game/scenes/chinatown-exterior.ts
+++ b/src/game/scenes/chinatown-exterior.ts
@@ -1,125 +1,71 @@
 import Phaser from 'phaser';
+import BaseMapScene, { MapSceneConfig } from './BaseMapScene';
 import { PlayerController } from '../player/PlayerController';
 import { IPlayerMovementInput } from '../player/types/PlayerTypes';
-import { CollisionLoader } from '../utils/CollisionLoader';
-import { TriggerManager } from '../utils/TriggerManager';
 
-export default class ChinatownExterior extends Phaser.Scene {
+export default class ChinatownExterior extends BaseMapScene {
+    private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
+    private playerController!: PlayerController;
 
-	constructor() {
-		super("chinatown-exterior");
-	}
+    private sceneConfig: MapSceneConfig = {
+        collision: {
+            key: 'chinatownCollision',
+            path: 'assets/images/levels/chinatown-exterior.json',
+        },
+        triggers: {
+            entries: [
+                { tileX: 10, tileY: 20, targetScene: 'apartment-interior', key: 'door_left' },
+                { tileX: 11, tileY: 20, targetScene: 'apartment-interior', key: 'door_right' },
+                { tileX: 16, tileY: 7, targetScene: 'ChessScene', key: 'chess_left' },
+                { tileX: 17, tileY: 7, targetScene: 'ChessScene', key: 'chess_right' },
+            ],
+        },
+    };
 
-	private player!: Phaser.Physics.Arcade.Sprite;
-	private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
-	private collisionGroup!: Phaser.Physics.Arcade.StaticGroup;
-	private playerController!: PlayerController;
-	private collisionLoader!: CollisionLoader;
-	private triggerManager!: TriggerManager;
-	private collisionRects: Phaser.GameObjects.Rectangle[] = [];
+    constructor() {
+        super('chinatown-exterior');
+    }
 
-	preload() {
-		// Initialize collision loader
-		this.collisionLoader = new CollisionLoader(this);
-		
-		// Load slice collision data from chinatown-exterior.json
-		this.collisionLoader.loadSliceCollision('chinatownCollision', 'assets/images/levels/chinatown-exterior.json');
-		
-		// Handle load errors gracefully
-		this.load.on('loaderror', (file: any) => {
-			if (file.key === 'chinatownCollision') {
-				console.warn('Collision data not found for ChinatownExterior - no collision will be active');
-			}
-		});
-	}
+    preload() {
+        super.preload(this.sceneConfig);
+    }
 
-	create() {
-		// Background image - position at top-left of world (0,0) 
-		const bg = this.add.image(0, 0, "chinatown-exterior");
-		bg.setOrigin(0, 0); // Set origin to top-left so image starts at (0,0)
+    create() {
+        const bg = this.add.image(0, 0, 'chinatown-exterior');
+        bg.setOrigin(0, 0);
 
-		// Create the player physics sprite at position 40,25
-		this.player = this.physics.add.sprite(40, 25, 'loop-player');
-		this.player.play('player-idle-down');
+        this.player = this.physics.add.sprite(40, 25, 'loop-player');
+        this.player.play('player-idle-down');
+        this.player.setSize(12, 12);
+        this.player.setOffset(11, 20);
+        this.player.setCollideWorldBounds(true);
 
-		// Set up player physics body - 12x12 centered horizontally, bottom aligned
-		this.player.setSize(12, 12); // Collision box size
-		this.player.setOffset(11, 20); // Offset 11 pixels from left to center, 20 from top for bottom 12 pixels
-		this.player.setCollideWorldBounds(true);
+        this.cursors = this.input.keyboard!.createCursorKeys();
 
-		// Set up input
-		this.cursors = this.input.keyboard!.createCursorKeys();
+        this.physics.world.setBounds(0, 0, 720, 480);
+        this.cameras.main.setBounds(0, 0, 720, 480);
+        this.cameras.main.roundPixels = true;
+        this.cameras.main.startFollow(this.player, true);
 
-		// Set world bounds for physics and camera to match actual map size
-		this.physics.world.setBounds(0, 0, 720, 480);
-		this.cameras.main.setBounds(0, 0, 720, 480);
-		
-		// Enable pixel-perfect camera for pixel art (no sub-pixel rendering)
-		this.cameras.main.roundPixels = true;
-		
-		// Camera follows player with no smoothing for pixel art
-		this.cameras.main.startFollow(this.player, true); // true = roundPixels enabled
+        super.create(this.sceneConfig);
 
-		// Create slice-based collision system
-		this.collisionGroup = this.physics.add.staticGroup();
-		this.setupSliceCollision();
+        this.playerController = new PlayerController(this.player);
+    }
 
-		// Initialize trigger system
-		this.triggerManager = new TriggerManager(this);
-		this.setupTriggers();
+    update() {
+        const input: IPlayerMovementInput = {
+            up: this.cursors.up.isDown,
+            down: this.cursors.down.isDown,
+            left: this.cursors.left.isDown,
+            right: this.cursors.right.isDown,
+        };
 
-		// Initialize player controller
-		this.playerController = new PlayerController(this.player);
-	}
+        this.playerController.update(input);
 
-	private setupSliceCollision() {
-		// Create collision bodies from Aseprite slice data
-		this.collisionRects = this.collisionLoader.createSliceCollision('chinatownCollision', this.collisionGroup);
-		
-		// Setup player collision with the collision group
-		this.collisionLoader.setupPlayerCollision(this.player, this.collisionGroup);
-		
-		// Uncomment below to enable debug visualization (red rectangles)
-		// this.collisionLoader.enableDebugVisualization(this.collisionRects);
-		
-		console.log('✅ Slice-based collision system enabled for ChinatownExterior');
-	}
-
-	private setupTriggers() {
-		// Add scene transition triggers at tiles 10,20 and 11,20 -> apartment-interior
-		this.triggerManager.addSceneTrigger(10, 20, 'apartment-interior', 'door_left');
-		this.triggerManager.addSceneTrigger(11, 20, 'apartment-interior', 'door_right');
-		
-		        // Add chess scene triggers at tiles 16,7 and 17,7
-        this.triggerManager.addSceneTrigger(16, 7, 'ChessScene', 'chess_left');
-        this.triggerManager.addSceneTrigger(17, 7, 'ChessScene', 'chess_right');
-
-        // Setup player trigger collision
-		this.triggerManager.setupPlayerTriggers(this.player);
-		
-		// Uncomment below to enable debug visualization (green rectangles)
-		// this.triggerManager.enableDebugVisualization();
-		
-		console.log('✅ Scene triggers setup: tiles (10,20) and (11,20) -> apartment-interior');
-	}
-
-	update() {
-		// Create input object from cursors
-		const input: IPlayerMovementInput = {
-			up: this.cursors.up.isDown,
-			down: this.cursors.down.isDown,
-			left: this.cursors.left.isDown,
-			right: this.cursors.right.isDown
-		};
-
-		// Update player via controller
-		this.playerController.update(input);
-
-		// Debug log when moving (maintain existing debug behavior)
-		const playerState = this.playerController.getState();
-		if (playerState.currentState === 'walking') {
-			const sprite = this.playerController.getSprite();
-			console.log(`Moving: ${playerState.lastDirection}, Position: ${sprite.x}, ${sprite.y}`);
-		}
-	}
+        const playerState = this.playerController.getState();
+        if (playerState.currentState === 'walking') {
+            const sprite = this.playerController.getSprite();
+            console.log(`Moving: ${playerState.lastDirection}, Position: ${sprite.x}, ${sprite.y}`);
+        }
+    }
 }

--- a/src/game/scenes/pacc-house-interior.ts
+++ b/src/game/scenes/pacc-house-interior.ts
@@ -1,96 +1,62 @@
 import Phaser from 'phaser';
+import BaseMapScene, { MapSceneConfig } from './BaseMapScene';
 import { PlayerController } from '../player/PlayerController';
 import { IPlayerMovementInput } from '../player/types/PlayerTypes';
-import { CollisionLoader } from '../utils/CollisionLoader';
 
-export default class PaccHouse extends Phaser.Scene {
+export default class PaccHouse extends BaseMapScene {
+    private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
+    private playerController!: PlayerController;
 
-	constructor() {
-		super("pacc-house");
-	}
+    private sceneConfig: MapSceneConfig = {
+        collision: {
+            key: 'paccHouseCollision',
+            path: 'assets/images/levels/pacc-house-interior.json',
+        },
+    };
 
-	private player!: Phaser.Physics.Arcade.Sprite;
-	private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
-	private collisionGroup!: Phaser.Physics.Arcade.StaticGroup;
-	private playerController!: PlayerController;
-	private collisionLoader!: CollisionLoader;
-	private collisionRects: Phaser.GameObjects.Rectangle[] = [];
+    constructor() {
+        super('pacc-house');
+    }
 
-	preload() {
-		// Initialize collision loader
-		this.collisionLoader = new CollisionLoader(this);
-		
-		// Load slice collision data from pacc-house-interior.json
-		this.collisionLoader.loadSliceCollision('paccHouseCollision', 'assets/images/levels/pacc-house-interior.json');
-		
-		// Handle load errors gracefully
-		this.load.on('loaderror', (file: any) => {
-			if (file.key === 'paccHouseCollision') {
-				console.warn('Collision data not found for PaccHouse - no collision will be active');
-			}
-		});
-	}
+    preload() {
+        super.preload(this.sceneConfig);
+    }
 
-	create() {
-		// Background image
-		this.add.image(192, 144, "pacc-house-interior");
+    create() {
+        this.add.image(192, 144, 'pacc-house-interior');
 
-		// Create the player physics sprite at center of screen
-		this.player = this.physics.add.sprite(192, 144, 'loop-player');
-		this.player.play('player-idle-down');
+        this.player = this.physics.add.sprite(192, 144, 'loop-player');
+        this.player.play('player-idle-down');
+        this.player.setSize(12, 12);
+        this.player.setOffset(10, 20);
+        this.player.setCollideWorldBounds(true);
 
-		// Set up player physics body - 12x12 centered horizontally, bottom aligned
-		this.player.setSize(12, 12); // Collision box size
-		this.player.setOffset(10, 20); // Offset 10 pixels from left to center, 20 from top for bottom 12 pixels
-		this.player.setCollideWorldBounds(true);
+        this.cursors = this.input.keyboard!.createCursorKeys();
 
-		// Set up input
-		this.cursors = this.input.keyboard!.createCursorKeys();
+        this.physics.world.setBounds(0, 0, 384, 288);
+        this.cameras.main.setBounds(0, 0, 384, 288);
+        this.cameras.main.startFollow(this.player);
+        this.cameras.main.setLerp(0.1, 0.1);
 
-		// Set world bounds for physics and camera
-		this.physics.world.setBounds(0, 0, 384, 288);
-		this.cameras.main.setBounds(0, 0, 384, 288);
-		this.cameras.main.startFollow(this.player);
-		this.cameras.main.setLerp(0.1, 0.1);
+        super.create(this.sceneConfig);
 
-		// Create slice-based collision system
-		this.collisionGroup = this.physics.add.staticGroup();
-		this.setupSliceCollision();
+        this.playerController = new PlayerController(this.player);
+    }
 
-		// Initialize player controller
-		this.playerController = new PlayerController(this.player);
-	}
+    update() {
+        const input: IPlayerMovementInput = {
+            up: this.cursors.up.isDown,
+            down: this.cursors.down.isDown,
+            left: this.cursors.left.isDown,
+            right: this.cursors.right.isDown,
+        };
 
-	private setupSliceCollision() {
-		// Create collision bodies from Aseprite slice data
-		this.collisionRects = this.collisionLoader.createSliceCollision('paccHouseCollision', this.collisionGroup);
-		
-		// Setup player collision with the collision group
-		this.collisionLoader.setupPlayerCollision(this.player, this.collisionGroup);
-		
-		// Uncomment below to enable debug visualization (red rectangles)
-		// this.collisionLoader.enableDebugVisualization(this.collisionRects);
-		
-		console.log('✅ Slice-based collision system enabled for PaccHouse');
-	}
+        this.playerController.update(input);
 
-	update() {
-		// Create input object from cursors
-		const input: IPlayerMovementInput = {
-			up: this.cursors.up.isDown,
-			down: this.cursors.down.isDown,
-			left: this.cursors.left.isDown,
-			right: this.cursors.right.isDown
-		};
-
-		// Update player via controller
-		this.playerController.update(input);
-
-		// Debug log when moving (maintain existing debug behavior)
-		const playerState = this.playerController.getState();
-		if (playerState.currentState === 'walking') {
-			const sprite = this.playerController.getSprite();
-			console.log(`Moving: ${playerState.lastDirection}, Position: ${sprite.x}, ${sprite.y}`);
-		}
-	}
+        const playerState = this.playerController.getState();
+        if (playerState.currentState === 'walking') {
+            const sprite = this.playerController.getSprite();
+            console.log(`Moving: ${playerState.lastDirection}, Position: ${sprite.x}, ${sprite.y}`);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add `BaseMapScene` with `MapSceneConfig` to handle collision and triggers
- refactor map scenes to use `BaseMapScene` and supply configuration

## Testing
- `npm run build` (fails: Could not resolve "./scenes/preloader" from "src/game/main.ts")

------
https://chatgpt.com/codex/tasks/task_e_689a7d6cb4d0832bbcf5dbd646b4236e