### PR TITLE
refactor scenes to share base map logic

### DIFF
--- a/src/game/scenes/BaseMapScene.ts
+++ b/src/game/scenes/BaseMapScene.ts
@@ -1,0 +1,57 @@
+import Phaser from 'phaser';
+import { PlayerController } from '../player/PlayerController';
+import { IPlayerMovementInput } from '../player/types/PlayerTypes';
+
+export default class BaseMapScene extends Phaser.Scene {
+    protected player!: Phaser.Physics.Arcade.Sprite;
+    protected cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
+    protected playerController!: PlayerController;
+
+    protected create(mapWidth: number, mapHeight: number, spawnX: number, spawnY: number): void {
+        this.createPlayer(spawnX, spawnY);
+        this.initWorld(mapWidth, mapHeight);
+        this.cursors = this.input.keyboard!.createCursorKeys();
+        this.playerController = new PlayerController(this.player);
+    }
+
+    protected createPlayer(x: number, y: number): void {
+        this.player = this.physics.add.sprite(x, y, 'loop-player');
+        this.player.play('player-idle-down');
+        this.player.setSize(12, 12);
+        this.player.setOffset(10, 20);
+        this.player.setCollideWorldBounds(true);
+    }
+
+    protected initWorld(width: number, height: number): void {
+        this.physics.world.setBounds(0, 0, width, height);
+        this.cameras.main.setBounds(0, 0, width, height);
+        this.cameras.main.startFollow(this.player);
+        this.cameras.main.setLerp(0.1, 0.1);
+        this.cameras.main.roundPixels = true;
+    }
+
+    update(time: number, delta: number): void {
+        this.handlePlayerUpdate();
+    }
+
+    protected handlePlayerUpdate(): void {
+        if (!this.cursors || !this.playerController) {
+            return;
+        }
+
+        const input: IPlayerMovementInput = {
+            up: this.cursors.up.isDown,
+            down: this.cursors.down.isDown,
+            left: this.cursors.left.isDown,
+            right: this.cursors.right.isDown,
+        };
+
+        this.playerController.update(input);
+
+        const playerState = this.playerController.getState();
+        if (playerState.currentState === 'walking') {
+            const sprite = this.playerController.getSprite();
+            console.log(`Moving: ${playerState.lastDirection}, Position: ${sprite.x}, ${sprite.y}`);
+        }
+    }
+}

--- a/src/game/scenes/apartment-interior.ts
+++ b/src/game/scenes/apartment-interior.ts
@@ -1,22 +1,18 @@
 import Phaser from 'phaser';
-import { PlayerController } from '../player/PlayerController';
-import { IPlayerMovementInput } from '../player/types/PlayerTypes';
 import { CollisionLoader } from '../utils/CollisionLoader';
 import { TriggerManager } from '../utils/TriggerManager';
+import BaseMapScene from './BaseMapScene';
 
-export default class ApartmentInterior extends Phaser.Scene {
+export default class ApartmentInterior extends BaseMapScene {
 
-	constructor() {
-		super("apartment-interior");
-	}
+        constructor() {
+                super("apartment-interior");
+        }
 
-	private player!: Phaser.Physics.Arcade.Sprite;
-	private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
-	private collisionGroup!: Phaser.Physics.Arcade.StaticGroup;
-	private playerController!: PlayerController;
-	private collisionLoader!: CollisionLoader;
-	private triggerManager!: TriggerManager;
-	private collisionRects: Phaser.GameObjects.Rectangle[] = [];
+        private collisionGroup!: Phaser.Physics.Arcade.StaticGroup;
+        private collisionLoader!: CollisionLoader;
+        private triggerManager!: TriggerManager;
+        private collisionRects: Phaser.GameObjects.Rectangle[] = [];
 
 	preload() {
 		// Initialize collision loader
@@ -33,39 +29,20 @@ export default class ApartmentInterior extends Phaser.Scene {
 		});
 	}
 
-	create() {
-		// Background image - using apartment-interior.png (without the "2")
-		this.add.image(192, 144, "apartment-interior");
+        create() {
+                // Background image - using apartment-interior.png (without the "2")
+                this.add.image(192, 144, "apartment-interior");
 
-		// Create the player physics sprite at center of screen
-		this.player = this.physics.add.sprite(192, 144, 'loop-player');
-		this.player.play('player-idle-down');
+                super.create(384, 288, 192, 144);
 
-		// Set up player physics body - 12x12 centered horizontally, bottom aligned
-		this.player.setSize(12, 12); // Collision box size
-		this.player.setOffset(11, 20); // Offset 11 pixels from left to center, 20 from top for bottom 12 pixels
-		this.player.setCollideWorldBounds(true);
+                // Create slice-based collision system
+                this.collisionGroup = this.physics.add.staticGroup();
+                this.setupSliceCollision();
 
-		// Set up input
-		this.cursors = this.input.keyboard!.createCursorKeys();
-
-		// Set world bounds for physics and camera
-		this.physics.world.setBounds(0, 0, 384, 288);
-		this.cameras.main.setBounds(0, 0, 384, 288);
-		this.cameras.main.startFollow(this.player);
-		this.cameras.main.setLerp(0.1, 0.1);
-
-		// Create slice-based collision system
-		this.collisionGroup = this.physics.add.staticGroup();
-		this.setupSliceCollision();
-
-		// Initialize trigger system
-		this.triggerManager = new TriggerManager(this);
-		this.setupTriggers();
-
-		// Initialize player controller
-		this.playerController = new PlayerController(this.player);
-	}
+                // Initialize trigger system
+                this.triggerManager = new TriggerManager(this);
+                this.setupTriggers();
+        }
 
 	private setupSliceCollision() {
 		// Create collision bodies from Aseprite slice data
@@ -80,39 +57,19 @@ export default class ApartmentInterior extends Phaser.Scene {
 		console.log('✅ Slice-based collision system enabled for ApartmentInterior');
 	}
 
-	private setupTriggers() {
-		// Add scene transition triggers at tiles 11,15 and 12,15 -> pacc-house
-		// Grid: 24x18 tiles (0-23 horizontal, 0-17 vertical)
-		// Tile 15 = row 15 out of 18 = near bottom of room
-		this.triggerManager.addSceneTrigger(11, 15, 'pacc-house', 'door_left');
-		this.triggerManager.addSceneTrigger(12, 15, 'pacc-house', 'door_right');
-		
-		// Setup player trigger collision
-		this.triggerManager.setupPlayerTriggers(this.player);
-		
-		// Uncomment below to enable debug visualization (green rectangles)
-		// this.triggerManager.enableDebugVisualization();
-		
-		console.log('✅ Scene triggers setup: tiles (11,15) and (12,15) -> pacc-house');
-	}
+        private setupTriggers() {
+                // Add scene transition triggers at tiles 11,15 and 12,15 -> pacc-house
+                // Grid: 24x18 tiles (0-23 horizontal, 0-17 vertical)
+                // Tile 15 = row 15 out of 18 = near bottom of room
+                this.triggerManager.addSceneTrigger(11, 15, 'pacc-house', 'door_left');
+                this.triggerManager.addSceneTrigger(12, 15, 'pacc-house', 'door_right');
 
-	update() {
-		// Create input object from cursors
-		const input: IPlayerMovementInput = {
-			up: this.cursors.up.isDown,
-			down: this.cursors.down.isDown,
-			left: this.cursors.left.isDown,
-			right: this.cursors.right.isDown
-		};
+                // Setup player trigger collision
+                this.triggerManager.setupPlayerTriggers(this.player);
 
-		// Update player via controller
-		this.playerController.update(input);
+                // Uncomment below to enable debug visualization (green rectangles)
+                // this.triggerManager.enableDebugVisualization();
 
-		// Debug log when moving (maintain existing debug behavior)
-		const playerState = this.playerController.getState();
-		if (playerState.currentState === 'walking') {
-			const sprite = this.playerController.getSprite();
-			console.log(`Moving: ${playerState.lastDirection}, Position: ${sprite.x}, ${sprite.y}`);
-		}
-	}
+                console.log('✅ Scene triggers setup: tiles (11,15) and (12,15) -> pacc-house');
+        }
 }

--- a/src/game/scenes/chinatown-exterior.ts
+++ b/src/game/scenes/chinatown-exterior.ts
@@ -1,22 +1,18 @@
 import Phaser from 'phaser';
-import { PlayerController } from '../player/PlayerController';
-import { IPlayerMovementInput } from '../player/types/PlayerTypes';
 import { CollisionLoader } from '../utils/CollisionLoader';
 import { TriggerManager } from '../utils/TriggerManager';
+import BaseMapScene from './BaseMapScene';
 
-export default class ChinatownExterior extends Phaser.Scene {
+export default class ChinatownExterior extends BaseMapScene {
 
-	constructor() {
-		super("chinatown-exterior");
-	}
+        constructor() {
+                super("chinatown-exterior");
+        }
 
-	private player!: Phaser.Physics.Arcade.Sprite;
-	private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
-	private collisionGroup!: Phaser.Physics.Arcade.StaticGroup;
-	private playerController!: PlayerController;
-	private collisionLoader!: CollisionLoader;
-	private triggerManager!: TriggerManager;
-	private collisionRects: Phaser.GameObjects.Rectangle[] = [];
+        private collisionGroup!: Phaser.Physics.Arcade.StaticGroup;
+        private collisionLoader!: CollisionLoader;
+        private triggerManager!: TriggerManager;
+        private collisionRects: Phaser.GameObjects.Rectangle[] = [];
 
 	preload() {
 		// Initialize collision loader
@@ -33,44 +29,22 @@ export default class ChinatownExterior extends Phaser.Scene {
 		});
 	}
 
-	create() {
-		// Background image - position at top-left of world (0,0) 
-		const bg = this.add.image(0, 0, "chinatown-exterior");
-		bg.setOrigin(0, 0); // Set origin to top-left so image starts at (0,0)
+        create() {
+                // Background image - position at top-left of world (0,0)
+                const bg = this.add.image(0, 0, "chinatown-exterior");
+                bg.setOrigin(0, 0); // Set origin to top-left so image starts at (0,0)
 
-		// Create the player physics sprite at position 40,25
-		this.player = this.physics.add.sprite(40, 25, 'loop-player');
-		this.player.play('player-idle-down');
+                super.create(720, 480, 40, 25);
+                this.cameras.main.setLerp(1, 1);
 
-		// Set up player physics body - 12x12 centered horizontally, bottom aligned
-		this.player.setSize(12, 12); // Collision box size
-		this.player.setOffset(11, 20); // Offset 11 pixels from left to center, 20 from top for bottom 12 pixels
-		this.player.setCollideWorldBounds(true);
+                // Create slice-based collision system
+                this.collisionGroup = this.physics.add.staticGroup();
+                this.setupSliceCollision();
 
-		// Set up input
-		this.cursors = this.input.keyboard!.createCursorKeys();
-
-		// Set world bounds for physics and camera to match actual map size
-		this.physics.world.setBounds(0, 0, 720, 480);
-		this.cameras.main.setBounds(0, 0, 720, 480);
-		
-		// Enable pixel-perfect camera for pixel art (no sub-pixel rendering)
-		this.cameras.main.roundPixels = true;
-		
-		// Camera follows player with no smoothing for pixel art
-		this.cameras.main.startFollow(this.player, true); // true = roundPixels enabled
-
-		// Create slice-based collision system
-		this.collisionGroup = this.physics.add.staticGroup();
-		this.setupSliceCollision();
-
-		// Initialize trigger system
-		this.triggerManager = new TriggerManager(this);
-		this.setupTriggers();
-
-		// Initialize player controller
-		this.playerController = new PlayerController(this.player);
-	}
+                // Initialize trigger system
+                this.triggerManager = new TriggerManager(this);
+                this.setupTriggers();
+        }
 
 	private setupSliceCollision() {
 		// Create collision bodies from Aseprite slice data
@@ -85,41 +59,21 @@ export default class ChinatownExterior extends Phaser.Scene {
 		console.log('✅ Slice-based collision system enabled for ChinatownExterior');
 	}
 
-	private setupTriggers() {
-		// Add scene transition triggers at tiles 10,20 and 11,20 -> apartment-interior
-		this.triggerManager.addSceneTrigger(10, 20, 'apartment-interior', 'door_left');
-		this.triggerManager.addSceneTrigger(11, 20, 'apartment-interior', 'door_right');
-		
-		        // Add chess scene triggers at tiles 16,7 and 17,7
-        this.triggerManager.addSceneTrigger(16, 7, 'ChessScene', 'chess_left');
-        this.triggerManager.addSceneTrigger(17, 7, 'ChessScene', 'chess_right');
+        private setupTriggers() {
+                // Add scene transition triggers at tiles 10,20 and 11,20 -> apartment-interior
+                this.triggerManager.addSceneTrigger(10, 20, 'apartment-interior', 'door_left');
+                this.triggerManager.addSceneTrigger(11, 20, 'apartment-interior', 'door_right');
 
-        // Setup player trigger collision
-		this.triggerManager.setupPlayerTriggers(this.player);
-		
-		// Uncomment below to enable debug visualization (green rectangles)
-		// this.triggerManager.enableDebugVisualization();
-		
-		console.log('✅ Scene triggers setup: tiles (10,20) and (11,20) -> apartment-interior');
-	}
+                // Add chess scene triggers at tiles 16,7 and 17,7
+                this.triggerManager.addSceneTrigger(16, 7, 'ChessScene', 'chess_left');
+                this.triggerManager.addSceneTrigger(17, 7, 'ChessScene', 'chess_right');
 
-	update() {
-		// Create input object from cursors
-		const input: IPlayerMovementInput = {
-			up: this.cursors.up.isDown,
-			down: this.cursors.down.isDown,
-			left: this.cursors.left.isDown,
-			right: this.cursors.right.isDown
-		};
+                // Setup player trigger collision
+                this.triggerManager.setupPlayerTriggers(this.player);
 
-		// Update player via controller
-		this.playerController.update(input);
+                // Uncomment below to enable debug visualization (green rectangles)
+                // this.triggerManager.enableDebugVisualization();
 
-		// Debug log when moving (maintain existing debug behavior)
-		const playerState = this.playerController.getState();
-		if (playerState.currentState === 'walking') {
-			const sprite = this.playerController.getSprite();
-			console.log(`Moving: ${playerState.lastDirection}, Position: ${sprite.x}, ${sprite.y}`);
-		}
-	}
+                console.log('✅ Scene triggers setup: tiles (10,20) and (11,20) -> apartment-interior');
+        }
 }

--- a/src/game/scenes/pacc-house-interior.ts
+++ b/src/game/scenes/pacc-house-interior.ts
@@ -1,20 +1,16 @@
 import Phaser from 'phaser';
-import { PlayerController } from '../player/PlayerController';
-import { IPlayerMovementInput } from '../player/types/PlayerTypes';
 import { CollisionLoader } from '../utils/CollisionLoader';
+import BaseMapScene from './BaseMapScene';
 
-export default class PaccHouse extends Phaser.Scene {
+export default class PaccHouse extends BaseMapScene {
 
-	constructor() {
-		super("pacc-house");
-	}
+        constructor() {
+                super("pacc-house");
+        }
 
-	private player!: Phaser.Physics.Arcade.Sprite;
-	private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
-	private collisionGroup!: Phaser.Physics.Arcade.StaticGroup;
-	private playerController!: PlayerController;
-	private collisionLoader!: CollisionLoader;
-	private collisionRects: Phaser.GameObjects.Rectangle[] = [];
+        private collisionGroup!: Phaser.Physics.Arcade.StaticGroup;
+        private collisionLoader!: CollisionLoader;
+        private collisionRects: Phaser.GameObjects.Rectangle[] = [];
 
 	preload() {
 		// Initialize collision loader
@@ -31,66 +27,27 @@ export default class PaccHouse extends Phaser.Scene {
 		});
 	}
 
-	create() {
-		// Background image
-		this.add.image(192, 144, "pacc-house-interior");
+        create() {
+                // Background image
+                this.add.image(192, 144, "pacc-house-interior");
 
-		// Create the player physics sprite at center of screen
-		this.player = this.physics.add.sprite(192, 144, 'loop-player');
-		this.player.play('player-idle-down');
+                super.create(384, 288, 192, 144);
 
-		// Set up player physics body - 12x12 centered horizontally, bottom aligned
-		this.player.setSize(12, 12); // Collision box size
-		this.player.setOffset(10, 20); // Offset 10 pixels from left to center, 20 from top for bottom 12 pixels
-		this.player.setCollideWorldBounds(true);
+                // Create slice-based collision system
+                this.collisionGroup = this.physics.add.staticGroup();
+                this.setupSliceCollision();
+        }
 
-		// Set up input
-		this.cursors = this.input.keyboard!.createCursorKeys();
+        private setupSliceCollision() {
+                // Create collision bodies from Aseprite slice data
+                this.collisionRects = this.collisionLoader.createSliceCollision('paccHouseCollision', this.collisionGroup);
 
-		// Set world bounds for physics and camera
-		this.physics.world.setBounds(0, 0, 384, 288);
-		this.cameras.main.setBounds(0, 0, 384, 288);
-		this.cameras.main.startFollow(this.player);
-		this.cameras.main.setLerp(0.1, 0.1);
+                // Setup player collision with the collision group
+                this.collisionLoader.setupPlayerCollision(this.player, this.collisionGroup);
 
-		// Create slice-based collision system
-		this.collisionGroup = this.physics.add.staticGroup();
-		this.setupSliceCollision();
+                // Uncomment below to enable debug visualization (red rectangles)
+                // this.collisionLoader.enableDebugVisualization(this.collisionRects);
 
-		// Initialize player controller
-		this.playerController = new PlayerController(this.player);
-	}
-
-	private setupSliceCollision() {
-		// Create collision bodies from Aseprite slice data
-		this.collisionRects = this.collisionLoader.createSliceCollision('paccHouseCollision', this.collisionGroup);
-		
-		// Setup player collision with the collision group
-		this.collisionLoader.setupPlayerCollision(this.player, this.collisionGroup);
-		
-		// Uncomment below to enable debug visualization (red rectangles)
-		// this.collisionLoader.enableDebugVisualization(this.collisionRects);
-		
-		console.log('✅ Slice-based collision system enabled for PaccHouse');
-	}
-
-	update() {
-		// Create input object from cursors
-		const input: IPlayerMovementInput = {
-			up: this.cursors.up.isDown,
-			down: this.cursors.down.isDown,
-			left: this.cursors.left.isDown,
-			right: this.cursors.right.isDown
-		};
-
-		// Update player via controller
-		this.playerController.update(input);
-
-		// Debug log when moving (maintain existing debug behavior)
-		const playerState = this.playerController.getState();
-		if (playerState.currentState === 'walking') {
-			const sprite = this.playerController.getSprite();
-			console.log(`Moving: ${playerState.lastDirection}, Position: ${sprite.x}, ${sprite.y}`);
-		}
-	}
+                console.log('✅ Slice-based collision system enabled for PaccHouse');
+        }
 }

--- a/src/game/scenes/trap-house.ts
+++ b/src/game/scenes/trap-house.ts
@@ -1,53 +1,30 @@
 import Phaser from 'phaser';
-import { PlayerController } from '../player/PlayerController';
-import { IPlayerMovementInput } from '../player/types/PlayerTypes';
+import BaseMapScene from './BaseMapScene';
 
-export default class TrapHouse extends Phaser.Scene {
+export default class TrapHouse extends BaseMapScene {
 
-	constructor() {
-		super("TrapHouse");
-	}
+        constructor() {
+                super("TrapHouse");
+        }
 
-	private player!: Phaser.Physics.Arcade.Sprite;
-	private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
-	private collisionGroup!: Phaser.Physics.Arcade.StaticGroup;
-	private playerController!: PlayerController;
+        private collisionGroup!: Phaser.Physics.Arcade.StaticGroup;
 
-	create() {
-		// Background image
-		this.add.image(192, 144, "traphouse");
+        create() {
+                // Background image
+                this.add.image(192, 144, "traphouse");
 
-		// Create the player physics sprite at center of screen
-		this.player = this.physics.add.sprite(192, 144, 'loop-player');
-		this.player.play('player-idle-down');
+                super.create(384, 288, 192, 144);
 
-		// Set up player physics body - 12x12 centered horizontally, bottom aligned
-		this.player.setSize(12, 12); // Collision box size
-		this.player.setOffset(10, 20); // Offset 10 pixels from left to center, 20 from top for bottom 12 pixels
-		this.player.setCollideWorldBounds(true);
+                // Create collision group for walls and obstacles
+                this.collisionGroup = this.physics.add.staticGroup();
 
-		// Set up input
-		this.cursors = this.input.keyboard!.createCursorKeys();
+                // Load tilemap data and create collision rectangles
+                this.createCollisionFromTilemap();
 
-		// Set world bounds for physics and camera
-		this.physics.world.setBounds(0, 0, 384, 288);
-		this.cameras.main.setBounds(0, 0, 384, 288);
-		this.cameras.main.startFollow(this.player);
-		this.cameras.main.setLerp(0.1, 0.1);
+                // Set up collision between player and collision group
+                this.physics.add.collider(this.player, this.collisionGroup);
 
-		// Create collision group for walls and obstacles
-		this.collisionGroup = this.physics.add.staticGroup();
-		
-		// Load tilemap data and create collision rectangles
-		this.createCollisionFromTilemap();
-
-		// Set up collision between player and collision group
-		this.physics.add.collider(this.player, this.collisionGroup);
-
-		// Initialize player controller
-		this.playerController = new PlayerController(this.player);
-
-	}
+        }
 
 	private createCollisionFromTilemap() {
 		// Get the tilemap data
@@ -79,23 +56,4 @@ export default class TrapHouse extends Phaser.Scene {
 		}
 	}
 
-	update() {
-		// Create input object from cursors
-		const input: IPlayerMovementInput = {
-			up: this.cursors.up.isDown,
-			down: this.cursors.down.isDown,
-			left: this.cursors.left.isDown,
-			right: this.cursors.right.isDown
-		};
-
-		// Update player via controller
-		this.playerController.update(input);
-
-		// Debug log when moving (maintain existing debug behavior)
-		const playerState = this.playerController.getState();
-		if (playerState.currentState === 'walking') {
-			const sprite = this.playerController.getSprite();
-			console.log(`Moving: ${playerState.lastDirection}, Position: ${sprite.x}, ${sprite.y}`);
-		}
-	}
 }


### PR DESCRIPTION
## Summary
- add a reusable `BaseMapScene` for spawning the player, camera bounds, and player update handling
- refactor map scenes to extend `BaseMapScene` and remove duplicated player/input/camera logic

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Could not resolve "./scenes/boot" from "src/game/main.ts")


------
https://chatgpt.com/codex/tasks/task_e_689a7af17c8c832bac74b8ead5c131bb